### PR TITLE
Extension method to create new method in typereference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 TestResult.xml
 *.user
 *.pdb
+*/*.ncrunchsolution*

--- a/src/FluentIL.Cecil/CecilExtensions.cs
+++ b/src/FluentIL.Cecil/CecilExtensions.cs
@@ -6,6 +6,7 @@ using Mono.Cecil;
 using FluentIL.Cecil.Emitters;
 using FluentIL.Infos;
 using System;
+using MethodAttributes = Mono.Cecil.MethodAttributes;
 
 namespace FluentIL.Cecil
 {
@@ -86,6 +87,28 @@ namespace FluentIL.Cecil
 
             var dinfo = new DynamicMethodInfo(emitter);
             that.LoadArgsTo(dinfo);
+
+            return dinfo.Body;
+        }
+
+        public static DynamicMethodBody NewMethod
+            (this TypeDefinition that, string methodName, MethodAttributes methodAttributes, Type returnType, AssemblyDefinition assembly)
+        {
+            var typeReference = assembly.MainModule.Import(returnType);
+            
+            var method = new MethodDefinition(methodName, methodAttributes, typeReference);
+            
+            ILProcessor worker = method.Body.GetILProcessor();
+
+            var emitter = new CecilILEmitter(
+                assembly,
+                worker,
+                method.Body.Instructions.Add);
+
+            var dinfo = new DynamicMethodInfo(emitter);
+            method.LoadArgsTo(dinfo);
+
+            that.Methods.Add(method);
 
             return dinfo.Body;
         }

--- a/src/FluentIL.Tests/CecilTests.cs
+++ b/src/FluentIL.Tests/CecilTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using FluentIL.Cecil;
+using Mono.Cecil;
+using NUnit.Framework;
+using SharpTestsEx;
+using SharpTestsEx.Assertions;
+
+namespace FluentIL.Tests
+{
+    [TestFixture]
+    public class CecilTests
+    {
+        [Test]
+        public void CanAddNewMethodToType()
+        {
+            var assemblyName = new AssemblyNameDefinition("TempAssembly", new Version(1, 0));
+            var assembly = AssemblyDefinition.CreateAssembly(assemblyName, "TempModule", ModuleKind.Dll);
+
+            var typeDefinition = new TypeDefinition("TempNamespace", "TempType", TypeAttributes.Public);
+
+            typeDefinition
+                .NewMethod("TempMethod", MethodAttributes.Public, typeof(string), assembly)
+                .Nop()
+                .Ldstr("Ola")
+                .Ret();
+
+            var methodDefinition = typeDefinition.Methods.First(x => x.Name == "TempMethod");
+            methodDefinition.Body.Instructions.Count.Should().Be.EqualTo(3);
+        }
+    }
+}

--- a/src/FluentIL.Tests/FluentIL.Tests.csproj
+++ b/src/FluentIL.Tests/FluentIL.Tests.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.2\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.5.8.10295, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\nunit.framework.dll</HintPath>
@@ -47,6 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CecilTests.cs" />
     <Compile Include="ConditionalStudies.cs" />
     <Compile Include="CounterStudies.cs" />
     <Compile Include="DynamicTypeInfoTests.cs" />
@@ -65,6 +69,10 @@
     <Compile Include="VariableStudies.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\FluentIL.Cecil\FluentIL.Cecil.csproj">
+      <Project>{449A3F1F-05FA-41CB-849A-66A0A3C4EF20}</Project>
+      <Name>FluentIL.Cecil</Name>
+    </ProjectReference>
     <ProjectReference Include="..\FluentIL\FluentIL.csproj">
       <Project>{3A793F01-7299-44F8-9BAF-0BACC23F4021}</Project>
       <Name>FluentIL</Name>


### PR DESCRIPTION
Added extension method to create new method in TypeReference

Example:

``` csharp

typeDefinition
    .NewMethod("TempMethod", MethodAttributes.Public, typeof(string), assembly)
    .Nop()
    .Ldstr("Ola")
    .Ret();

```
